### PR TITLE
Properly dereference record_data to check that it's set.

### DIFF
--- a/src/libusbmuxd.c
+++ b/src/libusbmuxd.c
@@ -1163,7 +1163,7 @@ int usbmuxd_read_pair_record(const char* record_id, char **record_data, uint32_t
 			if (node && plist_get_node_type(node) == PLIST_DATA) {
 				uint64_t int64val = 0;
 				plist_get_data_val(node, record_data, &int64val);
-				if (record_data && int64val > 0) {
+				if (*record_data && int64val > 0) {
 					*record_size = (uint32_t)int64val;
 					ret = 0;
 				}


### PR DESCRIPTION
The original version was checking that the parameter record_data was not NULL, but this is checked at the start of the function. The patched version checks that the call to plist_data_get_val() successfully returned a new buffer.
