### PR TITLE
Support Visual C++ in libusbmuxd

### DIFF
--- a/common/collection.c
+++ b/common/collection.c
@@ -23,6 +23,10 @@
 #include <config.h>
 #endif
 
+#ifdef _MSC_VER
+#define __func__ __FUNCTION__
+#endif
+
 #include <stdlib.h>
 #include <string.h>
 #include <stdio.h>

--- a/common/socket.c
+++ b/common/socket.c
@@ -19,13 +19,23 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  */
 
+#ifdef _MSC_VER
+#define __func__ __FUNCTION__
+#endif
+
 #include <stdio.h>
 #include <stddef.h>
 #include <stdlib.h>
 #include <string.h>
-#include <unistd.h>
+//#include <unistd.h>
 #include <errno.h>
+#ifdef _MSC_VER
+#pragma warning(disable:4996)
+#pragma warning(disable:4244)
+#include <winsock2.h>
+#else
 #include <sys/time.h>
+#endif
 #include <sys/stat.h>
 #ifdef WIN32
 #include <winsock2.h>

--- a/include/usbmuxd-proto.h
+++ b/include/usbmuxd-proto.h
@@ -36,6 +36,12 @@
 extern "C" {
 #endif
 
+#ifndef _MSC_VER
+#define PACK( __Declaration__ ) __Declaration__ __attribute__((__packed__))
+#else
+#define PACK( __Declaration__ ) __pragma( pack(push, 1) ) __Declaration__ __pragma( pack(pop) )
+#endif
+
 enum usbmuxd_result {
 	RESULT_OK = 0,
 	RESULT_BADCOMMAND = 1,
@@ -57,36 +63,36 @@ enum usbmuxd_msgtype {
 	MESSAGE_PLIST = 8,
 };
 
-struct usbmuxd_header {
+PACK(struct usbmuxd_header {
 	uint32_t length;    // length of message, including header
 	uint32_t version;   // protocol version
 	uint32_t message;   // message type
 	uint32_t tag;       // responses to this query will echo back this tag
-} __attribute__((__packed__));
+});
 
-struct usbmuxd_result_msg {
+PACK(struct usbmuxd_result_msg {
 	struct usbmuxd_header header;
 	uint32_t result;
-} __attribute__((__packed__));
+});
 
-struct usbmuxd_connect_request {
+PACK(struct usbmuxd_connect_request {
 	struct usbmuxd_header header;
 	uint32_t device_id;
 	uint16_t port;   // TCP port number
 	uint16_t reserved;   // set to zero
-} __attribute__((__packed__));
+});
 
-struct usbmuxd_listen_request {
+PACK(struct usbmuxd_listen_request {
 	struct usbmuxd_header header;
-} __attribute__((__packed__));
+});
 
-struct usbmuxd_device_record {
+PACK(struct usbmuxd_device_record {
 	uint32_t device_id;
 	uint16_t product_id;
 	char serial_number[256];
 	uint16_t padding;
 	uint32_t location;
-} __attribute__((__packed__));
+});
 
 #ifdef __cplusplus
 }

--- a/include/usbmuxd.h
+++ b/include/usbmuxd.h
@@ -24,6 +24,16 @@
 #define USBMUXD_H
 #include <stdint.h>
 
+#ifdef WIN32
+#define USBMUXD_API __declspec( dllexport )
+#else
+#ifdef HAVE_FVISIBILITY
+#define USBMUXD_API __attribute__((visibility("default")))
+#else
+#define USBMUXD_API
+#endif
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -71,14 +81,14 @@ typedef void (*usbmuxd_event_cb_t) (const usbmuxd_event_t *event, void *user_dat
  *
  * @return 0 on success or negative on error.
  */
-int usbmuxd_subscribe(usbmuxd_event_cb_t callback, void *user_data);
+USBMUXD_API int usbmuxd_subscribe(usbmuxd_event_cb_t callback, void *user_data);
 
 /**
  * Unsubscribe callback.
  *
  * @return only 0 for now.
  */
-int usbmuxd_unsubscribe();
+USBMUXD_API int usbmuxd_unsubscribe();
 
 /**
  * Contacts usbmuxd and retrieves a list of connected devices.
@@ -91,7 +101,7 @@ int usbmuxd_unsubscribe();
  * @return number of attached devices, zero on no devices, or negative
  *   if an error occured.
  */
-int usbmuxd_get_device_list(usbmuxd_device_info_t **device_list);
+USBMUXD_API int usbmuxd_get_device_list(usbmuxd_device_info_t **device_list);
 
 /**
  * Frees the device list returned by an usbmuxd_get_device_list call
@@ -100,7 +110,7 @@ int usbmuxd_get_device_list(usbmuxd_device_info_t **device_list);
  *
  * @return 0 on success, -1 on error.
  */
-int usbmuxd_device_list_free(usbmuxd_device_info_t **device_list);
+USBMUXD_API int usbmuxd_device_list_free(usbmuxd_device_info_t **device_list);
 
 /**
  * Gets device information for the device specified by udid.
@@ -113,7 +123,7 @@ int usbmuxd_device_list_free(usbmuxd_device_info_t **device_list);
  * @return 0 if no matching device is connected, 1 if the device was found,
  *    or a negative value on error.
  */
-int usbmuxd_get_device_by_udid(const char *udid, usbmuxd_device_info_t *device);
+USBMUXD_API int usbmuxd_get_device_by_udid(const char *udid, usbmuxd_device_info_t *device);
 
 /**
  * Request proxy connect to 
@@ -125,7 +135,7 @@ int usbmuxd_get_device_by_udid(const char *udid, usbmuxd_device_info_t *device);
  *
  * @return file descriptor socket of the connection, or -1 on error
  */
-int usbmuxd_connect(const int handle, const unsigned short tcp_port);
+USBMUXD_API int usbmuxd_connect(const int handle, const unsigned short tcp_port);
 
 /**
  * Disconnect. For now, this just closes the socket file descriptor.
@@ -134,7 +144,7 @@ int usbmuxd_connect(const int handle, const unsigned short tcp_port);
  *
  * @return 0 on success, -1 on error.
  */
-int usbmuxd_disconnect(int sfd);
+USBMUXD_API int usbmuxd_disconnect(int sfd);
 
 /**
  * Send data to the specified socket.
@@ -146,7 +156,7 @@ int usbmuxd_disconnect(int sfd);
  *
  * @return 0 on success, a negative errno value otherwise.
  */
-int usbmuxd_send(int sfd, const char *data, uint32_t len, uint32_t *sent_bytes);
+USBMUXD_API int usbmuxd_send(int sfd, const char *data, uint32_t len, uint32_t *sent_bytes);
 
 /**
  * Receive data from the specified socket.
@@ -159,7 +169,7 @@ int usbmuxd_send(int sfd, const char *data, uint32_t len, uint32_t *sent_bytes);
  *
  * @return 0 on success, a negative errno value otherwise.
  */
-int usbmuxd_recv_timeout(int sfd, char *data, uint32_t len, uint32_t *recv_bytes, unsigned int timeout);
+USBMUXD_API int usbmuxd_recv_timeout(int sfd, char *data, uint32_t len, uint32_t *recv_bytes, unsigned int timeout);
 
 /**
  * Receive data from the specified socket with a default timeout.
@@ -171,7 +181,7 @@ int usbmuxd_recv_timeout(int sfd, char *data, uint32_t len, uint32_t *recv_bytes
  *
  * @return 0 on success, a negative errno value otherwise.
  */
-int usbmuxd_recv(int sfd, char *data, uint32_t len, uint32_t *recv_bytes);
+USBMUXD_API int usbmuxd_recv(int sfd, char *data, uint32_t len, uint32_t *recv_bytes);
 
 /**
  * Reads the SystemBUID
@@ -181,7 +191,7 @@ int usbmuxd_recv(int sfd, char *data, uint32_t len, uint32_t *recv_bytes);
  *
  * @return 0 on success, a negative errno value otherwise.
  */
-int usbmuxd_read_buid(char** buid);
+USBMUXD_API int usbmuxd_read_buid(char** buid);
 
 /**
  * Read a pairing record
@@ -194,7 +204,7 @@ int usbmuxd_read_buid(char** buid);
  *
  * @return 0 on success, a negative error value otherwise.
  */
-int usbmuxd_read_pair_record(const char* record_id, char **record_data, uint32_t *record_size);
+USBMUXD_API int usbmuxd_read_pair_record(const char* record_id, char **record_data, uint32_t *record_size);
 
 /**
  * Save a pairing record
@@ -205,7 +215,7 @@ int usbmuxd_read_pair_record(const char* record_id, char **record_data, uint32_t
  *
  * @return 0 on success, a negative error value otherwise.
  */
-int usbmuxd_save_pair_record(const char* record_id, const char *record_data, uint32_t record_size);
+USBMUXD_API int usbmuxd_save_pair_record(const char* record_id, const char *record_data, uint32_t record_size);
 
 /**
  * Delete a pairing record
@@ -214,7 +224,7 @@ int usbmuxd_save_pair_record(const char* record_id, const char *record_data, uin
  *
  * @return 0 on success, a negative errno value otherwise.
  */
-int usbmuxd_delete_pair_record(const char* record_id);
+USBMUXD_API int usbmuxd_delete_pair_record(const char* record_id);
 
 /**
  * Enable or disable the use of inotify extension. Enabled by default.
@@ -222,9 +232,9 @@ int usbmuxd_delete_pair_record(const char* record_id);
  * This only has an effect on linux systems if inotify support has been built
  * in. Otherwise and on all other platforms this function has no effect.
  */
-void libusbmuxd_set_use_inotify(int set);
+USBMUXD_API void libusbmuxd_set_use_inotify(int set);
 
-void libusbmuxd_set_debug_level(int level);
+USBMUXD_API void libusbmuxd_set_debug_level(int level);
 
 #ifdef __cplusplus
 }

--- a/src/libusbmuxd.c
+++ b/src/libusbmuxd.c
@@ -677,10 +677,11 @@ static int get_next_event(int sfd, usbmuxd_event_cb_t callback, void *user_data)
 		memset(devinfo->udid, '\0', sizeof(devinfo->udid));
 		memcpy(devinfo->udid, dev->serial_number, sizeof(devinfo->udid));
 
-		if (strcasecmp(devinfo->udid, "ffffffffffffffffffffffffffffffffffffffff") == 0) {
 #ifndef _MSC_VER
+		if (strcasecmp(devinfo->udid, "ffffffffffffffffffffffffffffffffffffffff") == 0) {
 			sprintf(devinfo->udid + 32, "%08x", devinfo->handle);
 #else
+		if (_stricmp(devinfo->udid, "ffffffffffffffffffffffffffffffffffffffff") == 0) {
             sprintf_s(devinfo->udid + 32, 41, "%08x", devinfo->handle);
 #endif
 		}
@@ -818,10 +819,11 @@ static usbmuxd_device_info_t *device_info_from_device_record(struct usbmuxd_devi
 	memset(devinfo->udid, '\0', sizeof(devinfo->udid));
 	memcpy(devinfo->udid, dev->serial_number, sizeof(devinfo->udid));
 
-    if (strcasecmp(devinfo->udid, "ffffffffffffffffffffffffffffffffffffffff") == 0) {
 #ifndef _MSC_VER
+    if (strcasecmp(devinfo->udid, "ffffffffffffffffffffffffffffffffffffffff") == 0) {
 		sprintf(devinfo->udid + 32, "%08x", devinfo->handle);
 #else
+	if (_stricmp(devinfo->udid, "ffffffffffffffffffffffffffffffffffffffff") == 0) {
         sprintf_s(devinfo->udid + 32, 41, "%08x", devinfo->handle);
 #endif
 	}

--- a/src/libusbmuxd.c
+++ b/src/libusbmuxd.c
@@ -30,19 +30,13 @@
 #include <config.h>
 #endif
 
-#ifdef WIN32
-  #define USBMUXD_API __declspec( dllexport )
-#else
-  #ifdef HAVE_FVISIBILITY
-    #define USBMUXD_API __attribute__((visibility("default")))
-  #else
-    #define USBMUXD_API
-  #endif
+#ifdef _MSC_VER
+#define __func__ __FUNCTION__
 #endif
 
 #ifdef WIN32
-#include <windows.h>
 #include <winsock2.h>
+#include <windows.h>
 #define sleep(x) Sleep(x*1000)
 #ifndef EPROTO
 #define EPROTO 134
@@ -64,7 +58,7 @@
 #define USBMUXD_SOCKET_NAME "usbmuxd"
 #endif /* HAVE_INOTIFY */
 
-#include <unistd.h>
+//#include <unistd.h>
 #include <signal.h>
 
 #include <plist/plist.h>
@@ -154,7 +148,11 @@ static struct usbmuxd_device_record* device_record_from_plist(plist_t props)
 	if (n && plist_get_node_type(n) == PLIST_STRING) {
 		plist_get_string_val(n, &strval);
 		if (strval) {
+#ifndef _MSC_VER
 			strncpy(dev->serial_number, strval, 255);
+#else
+            strncpy_s(dev->serial_number, 255, strval, 255);
+#endif
 			free(strval);
 		}
 	}
@@ -680,7 +678,11 @@ static int get_next_event(int sfd, usbmuxd_event_cb_t callback, void *user_data)
 		memcpy(devinfo->udid, dev->serial_number, sizeof(devinfo->udid));
 
 		if (strcasecmp(devinfo->udid, "ffffffffffffffffffffffffffffffffffffffff") == 0) {
+#ifndef _MSC_VER
 			sprintf(devinfo->udid + 32, "%08x", devinfo->handle);
+#else
+            sprintf_s(devinfo->udid + 32, 41, "%08x", devinfo->handle);
+#endif
 		}
 
 		collection_add(&devices, devinfo);
@@ -816,8 +818,12 @@ static usbmuxd_device_info_t *device_info_from_device_record(struct usbmuxd_devi
 	memset(devinfo->udid, '\0', sizeof(devinfo->udid));
 	memcpy(devinfo->udid, dev->serial_number, sizeof(devinfo->udid));
 
-	if (strcasecmp(devinfo->udid, "ffffffffffffffffffffffffffffffffffffffff") == 0) {
+    if (strcasecmp(devinfo->udid, "ffffffffffffffffffffffffffffffffffffffff") == 0) {
+#ifndef _MSC_VER
 		sprintf(devinfo->udid + 32, "%08x", devinfo->handle);
+#else
+        sprintf_s(devinfo->udid + 32, 41, "%08x", devinfo->handle);
+#endif
 	}
 
 	return devinfo;
@@ -1001,14 +1007,22 @@ USBMUXD_API int usbmuxd_get_device_by_udid(const char *udid, usbmuxd_device_info
 	 	if (!udid) {
 			device->handle = dev_list[i].handle;
 			device->product_id = dev_list[i].product_id;
+#ifndef _MSC_VER
 			strcpy(device->udid, dev_list[i].udid);
+#else
+            strcpy_s(device->udid, 41, dev_list[i].udid);
+#endif
 			result = 1;
 			break;
 		}
 		if (!strcmp(udid, dev_list[i].udid)) {
 			device->handle = dev_list[i].handle;
-			device->product_id = dev_list[i].product_id;
-			strcpy(device->udid, dev_list[i].udid);
+            device->product_id = dev_list[i].product_id;
+#ifndef _MSC_VER
+            strcpy(device->udid, dev_list[i].udid);
+#else
+            strcpy_s(device->udid, 41, dev_list[i].udid);
+#endif
 			result = 1;
 			break;
 		}
@@ -1024,14 +1038,21 @@ USBMUXD_API int usbmuxd_connect(const int handle, const unsigned short port)
 	int sfd;
 	int tag;
 	int connected = 0;
-	uint32_t res = -1;
+    uint32_t res = -1;
+    char errmsg[256];
 
 retry:
 	sfd = connect_usbmuxd_socket();
 	if (sfd < 0) {
+#ifdef _MSC_VER
+        strerror_s(errmsg, 256, errno);
+        DEBUG(1, "%s: Error: Connection to usbmuxd failed: %s\n",
+            __func__, errmsg);
+#else
 		DEBUG(1, "%s: Error: Connection to usbmuxd failed: %s\n",
 				__func__, strerror(errno));
-		return sfd;
+#endif
+        return sfd;
 	}
 
 	tag = ++use_tag;
@@ -1072,6 +1093,7 @@ USBMUXD_API int usbmuxd_disconnect(int sfd)
 USBMUXD_API int usbmuxd_send(int sfd, const char *data, uint32_t len, uint32_t *sent_bytes)
 {
 	int num_sent;
+    char errmsg[256];
 
 	if (sfd < 0) {
 		return -EINVAL;
@@ -1081,7 +1103,12 @@ USBMUXD_API int usbmuxd_send(int sfd, const char *data, uint32_t len, uint32_t *
 	if (num_sent < 0) {
 		*sent_bytes = 0;
 		num_sent = errno;
+#ifdef _MSC_VER
+        strerror_s(errmsg, 256, errno);
+        DEBUG(1, "%s: Error %d when sending: %s\n", __func__, num_sent, errmsg);
+#else
 		DEBUG(1, "%s: Error %d when sending: %s\n", __func__, num_sent, strerror(num_sent));
+#endif
 		return -num_sent;
 	} else if ((uint32_t)num_sent < len) {
 		DEBUG(1, "%s: Warning: Did not send enough (only %d of %d)\n", __func__, num_sent, len);
@@ -1115,6 +1142,7 @@ USBMUXD_API int usbmuxd_read_buid(char **buid)
 	int sfd;
 	int tag;
 	int ret = -1;
+    char errmsg[256];
 
 	if (!buid) {
 		return -EINVAL;
@@ -1123,7 +1151,12 @@ USBMUXD_API int usbmuxd_read_buid(char **buid)
 
 	sfd = connect_usbmuxd_socket();
 	if (sfd < 0) {
+#ifdef _MSC_VER
+        strerror_s(errmsg, 256, errno);
+        DEBUG(1, "%s: Error: Connection to usbmuxd failed: %s\n", __func__, errmsg);
+#else
 		DEBUG(1, "%s: Error: Connection to usbmuxd failed: %s\n", __func__, strerror(errno));
+#endif
 		return sfd;
 	}
 
@@ -1156,6 +1189,7 @@ USBMUXD_API int usbmuxd_read_pair_record(const char* record_id, char **record_da
 	int sfd;
 	int tag;
 	int ret = -1;
+    char errmsg[256];
 
 	if (!record_id || !record_data || !record_size) {
 		return -EINVAL;
@@ -1165,8 +1199,14 @@ USBMUXD_API int usbmuxd_read_pair_record(const char* record_id, char **record_da
 
 	sfd = connect_usbmuxd_socket();
 	if (sfd < 0) {
+#ifdef _MSC_VER
+        strerror_s(errmsg, 256, errno);
+        DEBUG(1, "%s: Error: Connection to usbmuxd failed: %s\n",
+            __func__, errmsg);
+#else
 		DEBUG(1, "%s: Error: Connection to usbmuxd failed: %s\n",
 				__func__, strerror(errno));
+#endif
 		return sfd;
 	}
 
@@ -1204,6 +1244,7 @@ USBMUXD_API int usbmuxd_save_pair_record(const char* record_id, const char *reco
 	int sfd;
 	int tag;
 	int ret = -1;
+    char errmsg[256];
 
 	if (!record_id || !record_data || !record_size) {
 		return -EINVAL;
@@ -1211,8 +1252,14 @@ USBMUXD_API int usbmuxd_save_pair_record(const char* record_id, const char *reco
 
 	sfd = connect_usbmuxd_socket();
 	if (sfd < 0) {
+#ifdef _MSC_VER
+        strerror_s(errmsg, 256, errno);
+        DEBUG(1, "%s: Error: Connection to usbmuxd failed: %s\n",
+            __func__, errmsg);
+#else
 		DEBUG(1, "%s: Error: Connection to usbmuxd failed: %s\n",
 				__func__, strerror(errno));
+#endif
 		return sfd;
 	}
 
@@ -1243,6 +1290,7 @@ USBMUXD_API int usbmuxd_delete_pair_record(const char* record_id)
 	int sfd;
 	int tag;
 	int ret = -1;
+    char errmsg[256];
 
 	if (!record_id) {
 		return -EINVAL;
@@ -1250,8 +1298,14 @@ USBMUXD_API int usbmuxd_delete_pair_record(const char* record_id)
 
 	sfd = connect_usbmuxd_socket();
 	if (sfd < 0) {
+#ifdef _MSC_VER
+        strerror_s(errmsg, 256, errno);
+        DEBUG(1, "%s: Error: Connection to usbmuxd failed: %s\n",
+            __func__, errmsg);
+#else
 		DEBUG(1, "%s: Error: Connection to usbmuxd failed: %s\n",
 				__func__, strerror(errno));
+#endif
 		return sfd;
 	}
 


### PR DESCRIPTION
Hi,

This pull request adds support for Microsoft Visual C++ in libplist.

It only includes changes in the .h and .c files; the actual project files are not included to keep the libusbmuxd repository clean.

The changes break down to:
- Adding the USBMUXD_API prefix to the function declarations in the .h file. If nothing else; if you can already merge this (commit 2036548), you would greatly reduce the manual work required by the next person who attempts a port of the code.
- Declaration of functions with different names, like strcasecmp, __func__ vs __FUNCTION__ and the handling of __packed__
- Finally, usage of the "secure" functions like strcpy_s instead of strcpy. I'm not sure about the availability of these functions in gcc so it's a conditional compilation every time. By default, strcpy generates a compiler error in MSVC. There's a flag that overrides that, though. If you don't want it, skip commit 3ce7f9f  .

All feedback is welcome,

Frederik.
