### PR TITLE
Visual C++ Compatibility

### DIFF
--- a/common/collection.c
+++ b/common/collection.c
@@ -23,6 +23,10 @@
 #include <config.h>
 #endif
 
+#ifdef _MSC_VER 
+#include "..\src\msc_config.h"
+#endif
+
 #include <stdlib.h>
 #include <string.h>
 #include <stdio.h>

--- a/common/socket.c
+++ b/common/socket.c
@@ -19,6 +19,10 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  */
 
+#ifdef _MSC_VER 
+#include "..\src\msc_config.h"
+#endif
+
 #include <stdio.h>
 #include <stddef.h>
 #include <stdlib.h>

--- a/common/socket.c
+++ b/common/socket.c
@@ -34,6 +34,7 @@
 #include <windows.h>
 static int wsa_init = 0;
 #else
+#include <unistd.h>
 #include <sys/time.h>
 #include <sys/socket.h>
 #include <sys/un.h>

--- a/common/socket.c
+++ b/common/socket.c
@@ -27,15 +27,14 @@
 #include <stddef.h>
 #include <stdlib.h>
 #include <string.h>
-#include <unistd.h>
 #include <errno.h>
-#include <sys/time.h>
 #include <sys/stat.h>
 #ifdef WIN32
 #include <winsock2.h>
 #include <windows.h>
 static int wsa_init = 0;
 #else
+#include <sys/time.h>
 #include <sys/socket.h>
 #include <sys/un.h>
 #include <netinet/in.h>

--- a/include/usbmuxd-proto.h
+++ b/include/usbmuxd-proto.h
@@ -32,6 +32,12 @@
 #define USBMUXD_SOCKET_FILE "/var/run/usbmuxd"
 #endif
 
+#ifndef _MSC_VER
+#define PACK( __Declaration__ ) __Declaration__ __attribute__((__packed__))
+#else
+#define PACK( __Declaration__ ) __pragma( pack(push, 1) ) __Declaration__ __pragma( pack(pop) )
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -57,36 +63,36 @@ enum usbmuxd_msgtype {
 	MESSAGE_PLIST = 8,
 };
 
-struct usbmuxd_header {
+PACK(struct usbmuxd_header {
 	uint32_t length;    // length of message, including header
 	uint32_t version;   // protocol version
 	uint32_t message;   // message type
 	uint32_t tag;       // responses to this query will echo back this tag
-} __attribute__((__packed__));
+});
 
-struct usbmuxd_result_msg {
+PACK(struct usbmuxd_result_msg {
 	struct usbmuxd_header header;
 	uint32_t result;
-} __attribute__((__packed__));
+});
 
-struct usbmuxd_connect_request {
+PACK(struct usbmuxd_connect_request {
 	struct usbmuxd_header header;
 	uint32_t device_id;
 	uint16_t port;   // TCP port number
 	uint16_t reserved;   // set to zero
-} __attribute__((__packed__));
+});
 
-struct usbmuxd_listen_request {
+PACK(struct usbmuxd_listen_request {
 	struct usbmuxd_header header;
-} __attribute__((__packed__));
+});
 
-struct usbmuxd_device_record {
+PACK(struct usbmuxd_device_record {
 	uint32_t device_id;
 	uint16_t product_id;
 	char serial_number[256];
 	uint16_t padding;
 	uint32_t location;
-} __attribute__((__packed__));
+});
 
 #ifdef __cplusplus
 }

--- a/include/usbmuxd.h
+++ b/include/usbmuxd.h
@@ -24,6 +24,12 @@
 #define USBMUXD_H
 #include <stdint.h>
 
+#ifdef _MSC_VER
+#define USBMUXD_API_MSC __declspec( dllexport )
+#else
+#define USBMUXD_API_MSC
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -71,14 +77,14 @@ typedef void (*usbmuxd_event_cb_t) (const usbmuxd_event_t *event, void *user_dat
  *
  * @return 0 on success or negative on error.
  */
-int usbmuxd_subscribe(usbmuxd_event_cb_t callback, void *user_data);
+USBMUXD_API_MSC int usbmuxd_subscribe(usbmuxd_event_cb_t callback, void *user_data);
 
 /**
  * Unsubscribe callback.
  *
  * @return only 0 for now.
  */
-int usbmuxd_unsubscribe();
+USBMUXD_API_MSC int usbmuxd_unsubscribe();
 
 /**
  * Contacts usbmuxd and retrieves a list of connected devices.
@@ -91,7 +97,7 @@ int usbmuxd_unsubscribe();
  * @return number of attached devices, zero on no devices, or negative
  *   if an error occured.
  */
-int usbmuxd_get_device_list(usbmuxd_device_info_t **device_list);
+USBMUXD_API_MSC int usbmuxd_get_device_list(usbmuxd_device_info_t **device_list);
 
 /**
  * Frees the device list returned by an usbmuxd_get_device_list call
@@ -100,7 +106,7 @@ int usbmuxd_get_device_list(usbmuxd_device_info_t **device_list);
  *
  * @return 0 on success, -1 on error.
  */
-int usbmuxd_device_list_free(usbmuxd_device_info_t **device_list);
+USBMUXD_API_MSC int usbmuxd_device_list_free(usbmuxd_device_info_t **device_list);
 
 /**
  * Gets device information for the device specified by udid.
@@ -113,7 +119,7 @@ int usbmuxd_device_list_free(usbmuxd_device_info_t **device_list);
  * @return 0 if no matching device is connected, 1 if the device was found,
  *    or a negative value on error.
  */
-int usbmuxd_get_device_by_udid(const char *udid, usbmuxd_device_info_t *device);
+USBMUXD_API_MSC int usbmuxd_get_device_by_udid(const char *udid, usbmuxd_device_info_t *device);
 
 /**
  * Request proxy connect to 
@@ -125,7 +131,7 @@ int usbmuxd_get_device_by_udid(const char *udid, usbmuxd_device_info_t *device);
  *
  * @return file descriptor socket of the connection, or -1 on error
  */
-int usbmuxd_connect(const int handle, const unsigned short tcp_port);
+USBMUXD_API_MSC int usbmuxd_connect(const int handle, const unsigned short tcp_port);
 
 /**
  * Disconnect. For now, this just closes the socket file descriptor.
@@ -134,7 +140,7 @@ int usbmuxd_connect(const int handle, const unsigned short tcp_port);
  *
  * @return 0 on success, -1 on error.
  */
-int usbmuxd_disconnect(int sfd);
+USBMUXD_API_MSC int usbmuxd_disconnect(int sfd);
 
 /**
  * Send data to the specified socket.
@@ -146,7 +152,7 @@ int usbmuxd_disconnect(int sfd);
  *
  * @return 0 on success, a negative errno value otherwise.
  */
-int usbmuxd_send(int sfd, const char *data, uint32_t len, uint32_t *sent_bytes);
+USBMUXD_API_MSC int usbmuxd_send(int sfd, const char *data, uint32_t len, uint32_t *sent_bytes);
 
 /**
  * Receive data from the specified socket.
@@ -159,7 +165,7 @@ int usbmuxd_send(int sfd, const char *data, uint32_t len, uint32_t *sent_bytes);
  *
  * @return 0 on success, a negative errno value otherwise.
  */
-int usbmuxd_recv_timeout(int sfd, char *data, uint32_t len, uint32_t *recv_bytes, unsigned int timeout);
+USBMUXD_API_MSC int usbmuxd_recv_timeout(int sfd, char *data, uint32_t len, uint32_t *recv_bytes, unsigned int timeout);
 
 /**
  * Receive data from the specified socket with a default timeout.
@@ -171,7 +177,7 @@ int usbmuxd_recv_timeout(int sfd, char *data, uint32_t len, uint32_t *recv_bytes
  *
  * @return 0 on success, a negative errno value otherwise.
  */
-int usbmuxd_recv(int sfd, char *data, uint32_t len, uint32_t *recv_bytes);
+USBMUXD_API_MSC int usbmuxd_recv(int sfd, char *data, uint32_t len, uint32_t *recv_bytes);
 
 /**
  * Reads the SystemBUID
@@ -181,7 +187,7 @@ int usbmuxd_recv(int sfd, char *data, uint32_t len, uint32_t *recv_bytes);
  *
  * @return 0 on success, a negative errno value otherwise.
  */
-int usbmuxd_read_buid(char** buid);
+USBMUXD_API_MSC int usbmuxd_read_buid(char** buid);
 
 /**
  * Read a pairing record
@@ -194,7 +200,7 @@ int usbmuxd_read_buid(char** buid);
  *
  * @return 0 on success, a negative error value otherwise.
  */
-int usbmuxd_read_pair_record(const char* record_id, char **record_data, uint32_t *record_size);
+USBMUXD_API_MSC int usbmuxd_read_pair_record(const char* record_id, char **record_data, uint32_t *record_size);
 
 /**
  * Save a pairing record
@@ -205,7 +211,7 @@ int usbmuxd_read_pair_record(const char* record_id, char **record_data, uint32_t
  *
  * @return 0 on success, a negative error value otherwise.
  */
-int usbmuxd_save_pair_record(const char* record_id, const char *record_data, uint32_t record_size);
+USBMUXD_API_MSC int usbmuxd_save_pair_record(const char* record_id, const char *record_data, uint32_t record_size);
 
 /**
  * Delete a pairing record
@@ -214,7 +220,7 @@ int usbmuxd_save_pair_record(const char* record_id, const char *record_data, uin
  *
  * @return 0 on success, a negative errno value otherwise.
  */
-int usbmuxd_delete_pair_record(const char* record_id);
+USBMUXD_API_MSC int usbmuxd_delete_pair_record(const char* record_id);
 
 /**
  * Enable or disable the use of inotify extension. Enabled by default.
@@ -222,9 +228,9 @@ int usbmuxd_delete_pair_record(const char* record_id);
  * This only has an effect on linux systems if inotify support has been built
  * in. Otherwise and on all other platforms this function has no effect.
  */
-void libusbmuxd_set_use_inotify(int set);
+USBMUXD_API_MSC void libusbmuxd_set_use_inotify(int set);
 
-void libusbmuxd_set_debug_level(int level);
+USBMUXD_API_MSC void libusbmuxd_set_debug_level(int level);
 
 #ifdef __cplusplus
 }

--- a/src/libusbmuxd.c
+++ b/src/libusbmuxd.c
@@ -20,12 +20,6 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  */
 
-#include <stdint.h>
-#include <stdlib.h>
-#include <errno.h>
-#include <stdio.h>
-#include <string.h>
-
 #ifdef HAVE_CONFIG_H
 #include <config.h>
 #endif
@@ -33,6 +27,12 @@
 #ifdef _MSC_VER 
 #include "msc_config.h"
 #endif
+
+#include <stdint.h>
+#include <stdlib.h>
+#include <errno.h>
+#include <stdio.h>
+#include <string.h>
 
 #ifdef WIN32
   #define USBMUXD_API __declspec( dllexport )

--- a/src/libusbmuxd.c
+++ b/src/libusbmuxd.c
@@ -34,6 +34,9 @@
 #include <stdio.h>
 #include <string.h>
 
+#ifdef _MSC_VER
+  #define USBMUXD_API __declspec( dllexport )
+#else
 #ifdef WIN32
   #define USBMUXD_API __declspec( dllexport )
 #else
@@ -42,6 +45,7 @@
   #else
     #define USBMUXD_API
   #endif
+#endif
 #endif
 
 #ifdef WIN32
@@ -68,7 +72,6 @@
 #define USBMUXD_SOCKET_NAME "usbmuxd"
 #endif /* HAVE_INOTIFY */
 
-#include <unistd.h>
 #include <signal.h>
 
 #include <plist/plist.h>

--- a/src/libusbmuxd.c
+++ b/src/libusbmuxd.c
@@ -59,6 +59,7 @@
 #define EBADMSG 104
 #endif
 #else
+#include <unistd.h>
 #include <sys/socket.h>
 #include <arpa/inet.h>
 #include <pthread.h>

--- a/src/libusbmuxd.c
+++ b/src/libusbmuxd.c
@@ -30,6 +30,10 @@
 #include <config.h>
 #endif
 
+#ifdef _MSC_VER 
+#include "msc_config.h"
+#endif
+
 #ifdef WIN32
   #define USBMUXD_API __declspec( dllexport )
 #else

--- a/src/msc_config.h
+++ b/src/msc_config.h
@@ -26,4 +26,6 @@
 #define _CRT_SECURE_NO_WARNINGS
 #define _WINSOCK_DEPRECATED_NO_WARNINGS
 #define __func__ __FUNCTION__
+#define strncasecmp _strnicmp
+#define strcasecmp _stricmp
 #endif

--- a/src/msc_config.h
+++ b/src/msc_config.h
@@ -1,0 +1,29 @@
+/*
+* msc_config.h
+* Contains definitions that will help the Visual C++ compiler compile
+* the libimobiledevice code base.
+*
+* Copyright (c) 2015 Frederik Carlier, Quamotion bvba. All Rights Reserved.
+*
+* This library is free software; you can redistribute it and/or
+* modify it under the terms of the GNU Lesser General Public
+* License as published by the Free Software Foundation; either
+* version 2.1 of the License, or (at your option) any later version.
+*
+* This library is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+* Lesser General Public License for more details.
+*
+* You should have received a copy of the GNU Lesser General Public
+* License along with this library; if not, write to the Free Software
+* Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+
+#ifdef _MSC_VER
+#define inline __inline
+#define WIN32_LEAN_AND_MEAN
+#define _CRT_SECURE_NO_WARNINGS
+#define _WINSOCK_DEPRECATED_NO_WARNINGS
+#define __func__ __FUNCTION__
+#endif


### PR DESCRIPTION
This pull request fixes incompatibilities between the Visual C++ compiler and the libusbmuxd codebase.

It consists of these changes:

- In the public headers, the function definitions are now prefixed by `USBMUXD_API_MSC`. On the current codebase, Visual C++ generates a compiler C2375 because the function declarations in the public header and the source files differ. Recyling `USBMUXD_API` in the public headers doesn't work, because it value depends on what is defined in `config.h`, and that's specific to the libimobiledevice build, not what the user is building.
Instead, a new define `USBMUXD_API_MSC` is used which adds the `__declspec( dllexport )` prefix only if Visual C++ is used. `USBMUXD_API` is updated to always be `__declspec( dllexport )` when compiling with Visual C++.
-  Some `#include` statements were not compatibile with Visual C++ and this has been fixed. A lot of `unistd.h` includes were redundant and the have been removed.
- A `msc_config.h` file, which defines values such as `_CRT_SECURE_NO_WARNINGS` which work around Visual C++ compiler errors, and defines macros, functions,... that don't exist when compiling with the Visual C++ compiler. For example, __func__ is defined as __FUNCTION__.. This header must be included before any other header is included in the file; it is usually added right after the `config.h` header.
- A `msc_compat.h` file, which overrides function definitions in C++ that create compiler errors. For example, using `strdup` in Visual C++ creates an error asking you to use `_strdup` instead. This file defines `strdup` as `_strdup`, working around the issue.
- Packing structs is compiler-specific and this has been accounted for

The updated code compiles on Linux (see [Travis Build](https://travis-ci.org/libimobiledevice-win32/libusbmuxd/builds/59118255) ) and Windows (see [AppVeyor Build](https://ci.appveyor.com/project/qmfrederik/libusbmuxd) )