### PR TITLE
Report pthread_kill/pthread_join errors in usbmuxd_unsubscribe

### DIFF
--- a/src/libusbmuxd.c
+++ b/src/libusbmuxd.c
@@ -782,6 +782,7 @@ USBMUXD_API int usbmuxd_subscribe(usbmuxd_event_cb_t callback, void *user_data)
 
 USBMUXD_API int usbmuxd_unsubscribe()
 {
+	int res;
 	event_cb = NULL;
 
 	socket_shutdown(listenfd, SHUT_RDWR);
@@ -791,9 +792,13 @@ USBMUXD_API int usbmuxd_unsubscribe()
 		WaitForSingleObject(devmon, INFINITE);
 	}
 #else
-	if (pthread_kill(devmon, 0) == 0) {
+	res = pthread_kill(devmon, 0);
+	if (res == 0) {
 		pthread_cancel(devmon);
-		pthread_join(devmon, NULL);
+		res = pthread_join(devmon, NULL);
+	}
+	if ((res != 0) && (res != ESRCH)) {
+		return res;
 	}
 #endif
 


### PR DESCRIPTION
In order to avoid race condition between an usbmuxd_event_cb_t firing in
a different thread and usbmuxd_unsubscribe() being called, libusbmuxd
users must assume that once usbmuxd_unsubcribe() returns, no more
usbmuxd_event_cb_t callbacks will fire, but also that those which were
already started when usbmuxd_unsubcribe() is called will have completed.

usbmuxd_unsubcribe() tries to guarantee this, but
pthread_kill/pthread_join may fail, in which case this guarantee would
not hold. This commit makes sure an error is reported to the caller when
we get in this situation (though I'm not really sure how the caller
could handle it).