### PR TITLE
Fix building with Visual Studio 2015

### DIFF
--- a/common/socket.c
+++ b/common/socket.c
@@ -23,15 +23,16 @@
 #include <stddef.h>
 #include <stdlib.h>
 #include <string.h>
-#include <unistd.h>
 #include <errno.h>
-#include <sys/time.h>
 #include <sys/stat.h>
-#ifdef WIN32
+#ifdef _MSC_VER
+#include<time.h>
 #include <winsock2.h>
 #include <windows.h>
 static int wsa_init = 0;
 #else
+#include <unistd.h>
+#include <sys/time.h>
 #include <sys/socket.h>
 #include <sys/un.h>
 #include <netinet/in.h>

--- a/include/usbmuxd-proto.h
+++ b/include/usbmuxd-proto.h
@@ -28,7 +28,9 @@
 
 #if defined(WIN32) || defined(__CYGWIN__)
 #define USBMUXD_SOCKET_PORT 27015
-#else
+#define PACKED
+#else 
+#define PACKED __attribute__((__packed__))
 #define USBMUXD_SOCKET_FILE "/var/run/usbmuxd"
 #endif
 
@@ -57,28 +59,31 @@ enum usbmuxd_msgtype {
 	MESSAGE_PLIST = 8,
 };
 
+#ifdef _MSC_VER
+#pragma pack(push, 1)
+#endif
 struct usbmuxd_header {
 	uint32_t length;    // length of message, including header
 	uint32_t version;   // protocol version
 	uint32_t message;   // message type
 	uint32_t tag;       // responses to this query will echo back this tag
-} __attribute__((__packed__));
+} PACKED ;
 
 struct usbmuxd_result_msg {
 	struct usbmuxd_header header;
 	uint32_t result;
-} __attribute__((__packed__));
+} PACKED ;
 
 struct usbmuxd_connect_request {
 	struct usbmuxd_header header;
 	uint32_t device_id;
 	uint16_t port;   // TCP port number
 	uint16_t reserved;   // set to zero
-} __attribute__((__packed__));
+} PACKED ;
 
 struct usbmuxd_listen_request {
 	struct usbmuxd_header header;
-} __attribute__((__packed__));
+} PACKED ;
 
 struct usbmuxd_device_record {
 	uint32_t device_id;
@@ -86,7 +91,11 @@ struct usbmuxd_device_record {
 	char serial_number[256];
 	uint16_t padding;
 	uint32_t location;
-} __attribute__((__packed__));
+} PACKED ;
+
+#ifdef _MSC_VER
+#pragma pack(pop)
+#endif
 
 #ifdef __cplusplus
 }

--- a/include/usbmuxd.h
+++ b/include/usbmuxd.h
@@ -28,6 +28,16 @@
 extern "C" {
 #endif
 
+#ifdef _MSC_VER
+#ifdef LIBUSBMUXD_EXPORTS
+#define USBMUXD_API __declspec( dllexport )
+#else 
+#define USBMUXD_API __declspec( dllimport )
+#endif
+#else
+#define USBMUXD_API
+#endif
+
 /**
  * Device information structure holding data to identify the device.
  * The relevant 'handle' should be passed to 'usbmuxd_connect()', to
@@ -71,14 +81,14 @@ typedef void (*usbmuxd_event_cb_t) (const usbmuxd_event_t *event, void *user_dat
  *
  * @return 0 on success or negative on error.
  */
-int usbmuxd_subscribe(usbmuxd_event_cb_t callback, void *user_data);
+USBMUXD_API int usbmuxd_subscribe(usbmuxd_event_cb_t callback, void *user_data);
 
 /**
  * Unsubscribe callback.
  *
  * @return only 0 for now.
  */
-int usbmuxd_unsubscribe();
+USBMUXD_API int usbmuxd_unsubscribe();
 
 /**
  * Contacts usbmuxd and retrieves a list of connected devices.
@@ -91,7 +101,7 @@ int usbmuxd_unsubscribe();
  * @return number of attached devices, zero on no devices, or negative
  *   if an error occured.
  */
-int usbmuxd_get_device_list(usbmuxd_device_info_t **device_list);
+USBMUXD_API int usbmuxd_get_device_list(usbmuxd_device_info_t **device_list);
 
 /**
  * Frees the device list returned by an usbmuxd_get_device_list call
@@ -100,7 +110,7 @@ int usbmuxd_get_device_list(usbmuxd_device_info_t **device_list);
  *
  * @return 0 on success, -1 on error.
  */
-int usbmuxd_device_list_free(usbmuxd_device_info_t **device_list);
+USBMUXD_API int usbmuxd_device_list_free(usbmuxd_device_info_t **device_list);
 
 /**
  * Gets device information for the device specified by udid.
@@ -113,7 +123,7 @@ int usbmuxd_device_list_free(usbmuxd_device_info_t **device_list);
  * @return 0 if no matching device is connected, 1 if the device was found,
  *    or a negative value on error.
  */
-int usbmuxd_get_device_by_udid(const char *udid, usbmuxd_device_info_t *device);
+USBMUXD_API int usbmuxd_get_device_by_udid(const char *udid, usbmuxd_device_info_t *device);
 
 /**
  * Request proxy connect to 
@@ -125,7 +135,7 @@ int usbmuxd_get_device_by_udid(const char *udid, usbmuxd_device_info_t *device);
  *
  * @return file descriptor socket of the connection, or -1 on error
  */
-int usbmuxd_connect(const int handle, const unsigned short tcp_port);
+USBMUXD_API int usbmuxd_connect(const int handle, const unsigned short tcp_port);
 
 /**
  * Disconnect. For now, this just closes the socket file descriptor.
@@ -134,7 +144,7 @@ int usbmuxd_connect(const int handle, const unsigned short tcp_port);
  *
  * @return 0 on success, -1 on error.
  */
-int usbmuxd_disconnect(int sfd);
+USBMUXD_API int usbmuxd_disconnect(int sfd);
 
 /**
  * Send data to the specified socket.
@@ -146,7 +156,7 @@ int usbmuxd_disconnect(int sfd);
  *
  * @return 0 on success, a negative errno value otherwise.
  */
-int usbmuxd_send(int sfd, const char *data, uint32_t len, uint32_t *sent_bytes);
+USBMUXD_API int usbmuxd_send(int sfd, const char *data, uint32_t len, uint32_t *sent_bytes);
 
 /**
  * Receive data from the specified socket.
@@ -159,7 +169,7 @@ int usbmuxd_send(int sfd, const char *data, uint32_t len, uint32_t *sent_bytes);
  *
  * @return 0 on success, a negative errno value otherwise.
  */
-int usbmuxd_recv_timeout(int sfd, char *data, uint32_t len, uint32_t *recv_bytes, unsigned int timeout);
+USBMUXD_API int usbmuxd_recv_timeout(int sfd, char *data, uint32_t len, uint32_t *recv_bytes, unsigned int timeout);
 
 /**
  * Receive data from the specified socket with a default timeout.
@@ -171,7 +181,7 @@ int usbmuxd_recv_timeout(int sfd, char *data, uint32_t len, uint32_t *recv_bytes
  *
  * @return 0 on success, a negative errno value otherwise.
  */
-int usbmuxd_recv(int sfd, char *data, uint32_t len, uint32_t *recv_bytes);
+USBMUXD_API int usbmuxd_recv(int sfd, char *data, uint32_t len, uint32_t *recv_bytes);
 
 /**
  * Reads the SystemBUID
@@ -181,7 +191,7 @@ int usbmuxd_recv(int sfd, char *data, uint32_t len, uint32_t *recv_bytes);
  *
  * @return 0 on success, a negative errno value otherwise.
  */
-int usbmuxd_read_buid(char** buid);
+USBMUXD_API int usbmuxd_read_buid(char** buid);
 
 /**
  * Read a pairing record
@@ -194,7 +204,7 @@ int usbmuxd_read_buid(char** buid);
  *
  * @return 0 on success, a negative error value otherwise.
  */
-int usbmuxd_read_pair_record(const char* record_id, char **record_data, uint32_t *record_size);
+USBMUXD_API int usbmuxd_read_pair_record(const char* record_id, char **record_data, uint32_t *record_size);
 
 /**
  * Save a pairing record
@@ -205,7 +215,7 @@ int usbmuxd_read_pair_record(const char* record_id, char **record_data, uint32_t
  *
  * @return 0 on success, a negative error value otherwise.
  */
-int usbmuxd_save_pair_record(const char* record_id, const char *record_data, uint32_t record_size);
+USBMUXD_API int usbmuxd_save_pair_record(const char* record_id, const char *record_data, uint32_t record_size);
 
 /**
  * Delete a pairing record
@@ -214,7 +224,7 @@ int usbmuxd_save_pair_record(const char* record_id, const char *record_data, uin
  *
  * @return 0 on success, a negative errno value otherwise.
  */
-int usbmuxd_delete_pair_record(const char* record_id);
+USBMUXD_API int usbmuxd_delete_pair_record(const char* record_id);
 
 /**
  * Enable or disable the use of inotify extension. Enabled by default.
@@ -222,9 +232,9 @@ int usbmuxd_delete_pair_record(const char* record_id);
  * This only has an effect on linux systems if inotify support has been built
  * in. Otherwise and on all other platforms this function has no effect.
  */
-void libusbmuxd_set_use_inotify(int set);
+USBMUXD_API void libusbmuxd_set_use_inotify(int set);
 
-void libusbmuxd_set_debug_level(int level);
+USBMUXD_API void libusbmuxd_set_debug_level(int level);
 
 #ifdef __cplusplus
 }

--- a/src/libusbmuxd.c
+++ b/src/libusbmuxd.c
@@ -30,7 +30,7 @@
 #include <config.h>
 #endif
 
-#ifdef WIN32
+#ifdef _MSC_VER
   #define USBMUXD_API __declspec( dllexport )
 #else
   #ifdef HAVE_FVISIBILITY
@@ -40,8 +40,8 @@
   #endif
 #endif
 
-#ifdef WIN32
-#include <windows.h>
+#ifdef _MSC_VER
+#define strcasecmp _stricmp
 #include <winsock2.h>
 #define sleep(x) Sleep(x*1000)
 #ifndef EPROTO
@@ -64,7 +64,9 @@
 #define USBMUXD_SOCKET_NAME "usbmuxd"
 #endif /* HAVE_INOTIFY */
 
+#ifndef _MSC_VER
 #include <unistd.h>
+#endif
 #include <signal.h>
 
 #include <plist/plist.h>
@@ -962,7 +964,11 @@ got_device_list:
 	newlist = (usbmuxd_device_info_t*)malloc(sizeof(usbmuxd_device_info_t) * (collection_count(&tmpdevs) + 1));
 	dev_cnt = 0;
 	FOREACH(usbmuxd_device_info_t *di, &tmpdevs) {
+#ifdef NO_WIFI_DEVICES
+        if(di && di->product_id != 0) {
+#else
 		if (di) {
+#endif
 			memcpy(&newlist[dev_cnt], di, sizeof(usbmuxd_device_info_t));
 			free(di);
 			dev_cnt++;


### PR DESCRIPTION
Simple code changes to enable compilation with Visual Studio 2015.

There is one extra change where I add a preprocessor macro NO_WIFI_DEVICES to diable detection of wireless devices at compile time. This is needed for my application, I would appreciate it, if you could leave it in -- it's a two line change that harms nothing.
