### PR TITLE
Move EBADMSG and EPROTO defines out of the WIN32 ifdef

### DIFF
--- a/src/libusbmuxd.c
+++ b/src/libusbmuxd.c
@@ -40,16 +40,17 @@
   #endif
 #endif
 
-#ifdef WIN32
-#include <windows.h>
-#include <winsock2.h>
-#define sleep(x) Sleep(x*1000)
 #ifndef EPROTO
 #define EPROTO 134
 #endif
 #ifndef EBADMSG
 #define EBADMSG 104
 #endif
+
+#ifdef WIN32
+#include <windows.h>
+#include <winsock2.h>
+#define sleep(x) Sleep(x*1000)
 #else
 #include <sys/socket.h>
 #include <arpa/inet.h>


### PR DESCRIPTION
Fixes compilation on OpenBSD, which surprisingly doesn't have them.

References:
http://thread.gmane.org/gmane.os.openbsd.tech/38584/focus=38623
http://cvsweb.openbsd.org/cgi-bin/cvsweb/src/sys/sys/errno.h?rev=1.24&content-type=text/x-cvsweb-markup