### PR TITLE
Enable cross-compiling for ARM

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -62,9 +62,7 @@ AC_TYPE_UINT32_T
 AC_TYPE_UINT8_T
 
 # Checks for library functions.
-AC_FUNC_MALLOC
-AC_FUNC_REALLOC
-AC_CHECK_FUNCS([strcasecmp strdup strerror strndup])
+AC_CHECK_FUNCS([malloc reallo strcasecmp strdup strerror strndup])
 
 # Check for operating system
 AC_MSG_CHECKING([whether to enable WIN32 build settings])


### PR DESCRIPTION
When cross-compiling for ARM, `AC_FUNC_MALLOC` would resolve to `rpl_malloc`
which is undefined. The simplest fix seems to be to remove `AC_FUNC_MALLOC`
and `AC_FUNC_REALLOC`, and replace them with checks in `AC_CHECK_FUNC`
