### PR TITLE
Eliminate use of pthread_cancel()

### DIFF
--- a/common/socket.h
+++ b/common/socket.h
@@ -32,6 +32,8 @@ enum fd_mode {
 };
 typedef enum fd_mode fd_mode;
 
+#define SOCKET_CANCEL_FD_NONE -1
+
 #ifdef WIN32
 #include <winsock2.h>
 #define SHUT_RD SD_READ
@@ -47,7 +49,7 @@ int socket_connect_unix(const char *filename);
 #endif
 int socket_create(uint16_t port);
 int socket_connect(const char *addr, uint16_t port);
-int socket_check_fd(int fd, fd_mode fdm, unsigned int timeout);
+int socket_check_fd(int fd, fd_mode fdm, unsigned int timeout, int cancel_fd);
 int socket_accept(int fd, uint16_t port);
 
 int socket_shutdown(int fd, int how);
@@ -56,7 +58,7 @@ int socket_close(int fd);
 int socket_receive(int fd, void *data, size_t size);
 int socket_peek(int fd, void *data, size_t size);
 int socket_receive_timeout(int fd, void *data, size_t size, int flags,
-					 unsigned int timeout);
+					 unsigned int timeout, int cancel_fd);
 
 int socket_send(int fd, void *data, size_t size);
 

--- a/tools/iproxy.c
+++ b/tools/iproxy.c
@@ -65,7 +65,7 @@ static void *run_stoc_loop(void *arg)
 	printf("%s: fd = %d\n", __func__, cdata->fd);
 
 	while (!cdata->stop_stoc && cdata->fd > 0 && cdata->sfd > 0) {
-		recv_len = socket_receive_timeout(cdata->sfd, buffer, sizeof(buffer), 0, 5000);
+		recv_len = socket_receive_timeout(cdata->sfd, buffer, sizeof(buffer), 0, 5000, SOCKET_CANCEL_FD_NONE);
 		if (recv_len <= 0) {
 			if (recv_len == 0) {
 				// try again
@@ -118,7 +118,7 @@ static void *run_ctos_loop(void *arg)
 #endif
 
 	while (!cdata->stop_ctos && cdata->fd>0 && cdata->sfd>0) {
-		recv_len = socket_receive_timeout(cdata->fd, buffer, sizeof(buffer), 0, 5000);
+		recv_len = socket_receive_timeout(cdata->fd, buffer, sizeof(buffer), 0, 5000, SOCKET_CANCEL_FD_NONE);
 		if (recv_len <= 0) {
 			if (recv_len == 0) {
 				// try again


### PR DESCRIPTION
Would this be of upstream interest? My use-case is being able to run on
[rr](http://rr-project.org/), which doesn't support `pthread_cancel()`.

This is WIP as the `inotify`/`connect()` part is currently uninterruptible,
but I figured I would leave it at this if it's not of upstream interest, to
keep my changes to a minimum (I only use my branch to be able to run
[Frida](https://www.frida.re/) on rr).