### PR TITLE
filter out devices whose connection_type is USB to fix when devices c…

### DIFF
--- a/include/usbmuxd-proto.h
+++ b/include/usbmuxd-proto.h
@@ -84,6 +84,7 @@ struct usbmuxd_device_record {
 	uint32_t device_id;
 	uint16_t product_id;
 	char serial_number[256];
+    char connection_type[16];
 	uint16_t padding;
 	uint32_t location;
 } __attribute__((__packed__));

--- a/src/libusbmuxd.c
+++ b/src/libusbmuxd.c
@@ -916,7 +916,9 @@ retry:
                             }
                             collection_add(&tmpdevs, devinfo);
                         }
-						
+                        else {
+                            free(dev);
+                        }
 					}
 					plist_free(list);
 					goto got_device_list;


### PR DESCRIPTION
filter out devices whose connection_type is USB to fix when devices connected through WIFI they are also listed.

We encounter this issue when using iproxy to transmit packages from PC to iPhone, it actually connects to some other iPhone which are in the same network but not USB connected. And the real USB connected iPhone is ignored so it cannot get packages from PC. 