### PR TITLE
Misc fixes

### DIFF
--- a/common/socket.c
+++ b/common/socket.c
@@ -128,11 +128,11 @@ int socket_connect_unix(const char *filename)
 		return -1;
 	}
 
-	if (setsockopt(sfd, SOL_SOCKET, SO_SNDBUF, &bufsize, sizeof(int)) == -1) {
+	if (setsockopt(sfd, SOL_SOCKET, SO_SNDBUF, (void*)&bufsize, sizeof(int)) == -1) {
 		perror("Could not set send buffer for socket");
 	}
 
-	if (setsockopt(sfd, SOL_SOCKET, SO_RCVBUF, &bufsize, sizeof(int)) == -1) {
+	if (setsockopt(sfd, SOL_SOCKET, SO_RCVBUF, (void*)&bufsize, sizeof(int)) == -1) {
 		perror("Could not set receive buffer for socket");
 	}
 
@@ -275,11 +275,11 @@ int socket_connect(const char *addr, uint16_t port)
 		perror("Could not set TCP_NODELAY on socket");
 	}
 
-	if (setsockopt(sfd, SOL_SOCKET, SO_SNDBUF, &bufsize, sizeof(int)) == -1) {
+	if (setsockopt(sfd, SOL_SOCKET, SO_SNDBUF, (void*)&bufsize, sizeof(int)) == -1) {
 		perror("Could not set send buffer for socket");
 	}
 
-	if (setsockopt(sfd, SOL_SOCKET, SO_RCVBUF, &bufsize, sizeof(int)) == -1) {
+	if (setsockopt(sfd, SOL_SOCKET, SO_RCVBUF, (void*)&bufsize, sizeof(int)) == -1) {
 		perror("Could not set receive buffer for socket");
 	}
 

--- a/src/libusbmuxd.c
+++ b/src/libusbmuxd.c
@@ -1011,6 +1011,11 @@ static usbmuxd_device_info_t *device_info_from_device_record(struct usbmuxd_devi
 	memset(devinfo->udid, '\0', sizeof(devinfo->udid));
 	memcpy(devinfo->udid, dev->serial_number, sizeof(devinfo->udid));
 
+	if (strlen(devinfo->udid) == 24) {
+		memmove(&devinfo->udid[9], &devinfo->udid[8], 17);
+		devinfo->udid[8] = '-';
+	}
+
 	if (strcasecmp(devinfo->udid, "ffffffffffffffffffffffffffffffffffffffff") == 0) {
 		sprintf(devinfo->udid + 32, "%08x", devinfo->handle);
 	}


### PR DESCRIPTION
One is fixing some warnings I get the other is for compatibility with Apple usbmuxd which seems to send new format UDIDs without a dash but the dash is required everywhere else so make sure to add it here.