### PR TITLE
Use socket_close instead of close to close a socket

### DIFF
--- a/common/socket.c
+++ b/common/socket.c
@@ -307,7 +307,7 @@ int socket_connect(const char *addr, uint16_t port)
 				}
 			}
 		}
-		close(sfd);
+		socket_close(sfd);
 	}
 
 	freeaddrinfo(result);


### PR DESCRIPTION
Fix a regression introduced by 80fe6e859302cb771bb6b6f10feb1766d765778b. Passing a socket handle to `close` on Windows will cause an application crash.

This code path is hit on Windows when the Apple Mobile Device Service is not running.