### PR TITLE
Enable accepting connections from remote machines in network.

### DIFF
--- a/common/socket.c
+++ b/common/socket.c
@@ -210,7 +210,7 @@ int socket_create(uint16_t port)
 
 	memset((void *) &saddr, 0, sizeof(saddr));
 	saddr.sin_family = AF_INET;
-	saddr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+	saddr.sin_addr.s_addr = htonl(INADDR_ANY);
 	saddr.sin_port = htons(port);
 
 	if (0 > bind(sfd, (struct sockaddr *) &saddr, sizeof(saddr))) {


### PR DESCRIPTION
Socket binding in iProxy is updated to use `INADDR_ANY` instead of `INADDR_LOOPBACK` to allow accepting connections from other machines in network. This helps in having iProxy running one machine where multiple iOS devices are connected and any machine can send commands to the iPhones.

This is specifically helpful in iOS automation testing where one machine, connected with multiple iOS devices, is assigned for running tests while other machines can send command to this machine to be passed to iOS devices.