### PR TITLE
fix xcode warning

### DIFF
--- a/include/usbmuxd.h
+++ b/include/usbmuxd.h
@@ -132,7 +132,7 @@ int usbmuxd_subscribe(usbmuxd_event_cb_t callback, void *user_data);
  * @note Deprecated. Use usbmuxd_events_subscribe and usbmuxd_events_unsubscribe instead.
  * @see usbmuxd_events_unsubscribe
  */
-int usbmuxd_unsubscribe();
+int usbmuxd_unsubscribe(void);
 
 /**
  * Contacts usbmuxd and retrieves a list of connected devices.

--- a/src/libusbmuxd.c
+++ b/src/libusbmuxd.c
@@ -1242,7 +1242,7 @@ USBMUXD_API int usbmuxd_subscribe(usbmuxd_event_cb_t callback, void *user_data)
 	return usbmuxd_events_subscribe(&event_ctx, callback, user_data);
 }
 
-USBMUXD_API int usbmuxd_unsubscribe()
+USBMUXD_API int usbmuxd_unsubscribe(void)
 {
 	int res = usbmuxd_events_unsubscribe(event_ctx);
 	event_ctx = NULL;


### PR DESCRIPTION
```
int usbmuxd_unsubscribe();
```
 get this warning in Xcode:
```
This function declaration is not a prototype
```