### PR TITLE
clang-tidy: fix inconsistent declarations

### DIFF
--- a/common/socket.h
+++ b/common/socket.h
@@ -54,12 +54,12 @@ int socket_accept(int fd, uint16_t port);
 int socket_shutdown(int fd, int how);
 int socket_close(int fd);
 
-int socket_receive(int fd, void *data, size_t size);
-int socket_peek(int fd, void *data, size_t size);
-int socket_receive_timeout(int fd, void *data, size_t size, int flags,
+int socket_receive(int fd, void *data, size_t length);
+int socket_peek(int fd, void *data, size_t length);
+int socket_receive_timeout(int fd, void *data, size_t length, int flags,
 					 unsigned int timeout);
 
-int socket_send(int fd, void *data, size_t size);
+int socket_send(int fd, void *data, size_t length);
 
 void socket_set_verbose(int level);
 

--- a/include/usbmuxd.h
+++ b/include/usbmuxd.h
@@ -99,7 +99,7 @@ typedef struct usbmuxd_subscription_context* usbmuxd_subscription_context_t;
  *
  * @return 0 on success or a negative errno value.
  */
-int usbmuxd_events_subscribe(usbmuxd_subscription_context_t *context, usbmuxd_event_cb_t callback, void *user_data);
+int usbmuxd_events_subscribe(usbmuxd_subscription_context_t *ctx, usbmuxd_event_cb_t callback, void *user_data);
 
 /**
  * Unsubscribe callback function
@@ -108,7 +108,7 @@ int usbmuxd_events_subscribe(usbmuxd_subscription_context_t *context, usbmuxd_ev
  *
  * @return 0 on success or a negative errno value.
  */
-int usbmuxd_events_unsubscribe(usbmuxd_subscription_context_t context);
+int usbmuxd_events_unsubscribe(usbmuxd_subscription_context_t ctx);
 
 /**
  * Subscribe a callback (deprecated)


### PR DESCRIPTION
Found with readability-inconsistent-declaration-parameter-name

Signed-off-by: Rosen Penev <rosenp@gmail.com>