### PR TITLE
clang-tidy: remove pointless return

### DIFF
--- a/src/libusbmuxd.c
+++ b/src/libusbmuxd.c
@@ -1779,7 +1779,6 @@ USBMUXD_API void libusbmuxd_set_use_inotify(int set)
 #ifdef HAVE_INOTIFY
 	use_inotify = set;
 #endif
-	return;
 }
 
 USBMUXD_API void libusbmuxd_set_debug_level(int level)


### PR DESCRIPTION
Found with readability-redundant-control-flow

Signed-off-by: Rosen Penev <rosenp@gmail.com>