### PR TITLE
clang-tidy: do not use else after return

### DIFF
--- a/common/socket.c
+++ b/common/socket.c
@@ -738,14 +738,13 @@ static int32_t _sockaddr_in6_scope_id(struct sockaddr_in6* addr)
 			if (addr->sin6_scope_id == addr_in->sin6_scope_id) {
 				res = addr_in->sin6_scope_id;
 				break;
-			} else {
-				if ((addr_in->sin6_scope_id > addr->sin6_scope_id) && (res >= 0)) {
-					// use last valid scope id as we're past the requested scope id
-					break;
-				}
-				res = addr_in->sin6_scope_id;
-				continue;
 			}
+			if ((addr_in->sin6_scope_id > addr->sin6_scope_id) && (res >= 0)) {
+				// use last valid scope id as we're past the requested scope id
+				break;
+			}
+			res = addr_in->sin6_scope_id;
+			continue;
 		}
 
 		/* skip loopback interface if not already matched exactly above */

--- a/src/libusbmuxd.c
+++ b/src/libusbmuxd.c
@@ -340,7 +340,9 @@ static int receive_packet(int sfd, struct usbmuxd_header *header, void **payload
 			LIBUSBMUXD_DEBUG(1, "%s: Error receiving packet: %s\n", __func__, strerror(-recv_len));
 		}
 		return recv_len;
-	} else if ((size_t)recv_len < sizeof(hdr)) {
+	}
+
+	if ((size_t)recv_len < sizeof(hdr)) {
 		LIBUSBMUXD_DEBUG(1, "%s: Received packet is too small, got %d bytes!\n", __func__, recv_len);
 		return recv_len;
 	}
@@ -500,7 +502,9 @@ static int usbmuxd_get_result(int sfd, uint32_t tag, uint32_t *result, void **re
 		}
 		free(res);
 		return ret;
-	} else if (hdr.message == MESSAGE_PLIST) {
+	}
+
+	if (hdr.message == MESSAGE_PLIST) {
 		if (!result_plist) {
 			LIBUSBMUXD_DEBUG(1, "%s: MESSAGE_PLIST result but result_plist pointer is NULL!\n", __func__);
 			return -1;
@@ -923,7 +927,8 @@ static int usbmuxd_listen_inotify()
 		int r = pselect(inot_fd+1, &rfds, NULL, NULL, &tv, NULL);
 		if (r < 0) {
 			break;
-		} else if (r == 0) {
+		}
+		if (r == 0) {
 			continue;
 		}
 
@@ -1466,7 +1471,8 @@ USBMUXD_API int usbmuxd_get_device(const char *udid, usbmuxd_device_info_t *devi
 			if ((options & DEVICE_LOOKUP_USBMUX) && (dev_list[i].conn_type == CONNECTION_TYPE_USB)) {
 				dev_usbmuxd = &dev_list[i];
 				break;
-			} else if ((options & DEVICE_LOOKUP_NETWORK) && (dev_list[i].conn_type == CONNECTION_TYPE_NETWORK)) {
+			}
+			if ((options & DEVICE_LOOKUP_NETWORK) && (dev_list[i].conn_type == CONNECTION_TYPE_NETWORK)) {
 				dev_network = &dev_list[i];
 				break;
 			}
@@ -1577,7 +1583,8 @@ USBMUXD_API int usbmuxd_send(int sfd, const char *data, uint32_t len, uint32_t *
 		num_sent = errno;
 		LIBUSBMUXD_DEBUG(1, "%s: Error %d when sending: %s\n", __func__, num_sent, strerror(num_sent));
 		return -num_sent;
-	} else if ((uint32_t)num_sent < len) {
+	}
+	if ((uint32_t)num_sent < len) {
 		LIBUSBMUXD_DEBUG(1, "%s: Warning: Did not send enough (only %d of %d)\n", __func__, num_sent, len);
 	}
 

--- a/tools/inetcat.c
+++ b/tools/inetcat.c
@@ -197,7 +197,8 @@ int main(int argc, char **argv)
             if (dev_list[i].conn_type == CONNECTION_TYPE_USB && (lookup_opts & DEVICE_LOOKUP_USBMUX)) {
                 dev = &(dev_list[i]);
                 break;
-            } else if (dev_list[i].conn_type == CONNECTION_TYPE_NETWORK && (lookup_opts & DEVICE_LOOKUP_NETWORK)) {
+            }
+            if (dev_list[i].conn_type == CONNECTION_TYPE_NETWORK && (lookup_opts & DEVICE_LOOKUP_NETWORK)) {
                 dev = &(dev_list[i]);
                 break;
             }

--- a/tools/iproxy.c
+++ b/tools/iproxy.c
@@ -112,7 +112,8 @@ static void *acceptor_thread(void *arg)
 			if (dev_list[i].conn_type == CONNECTION_TYPE_USB && (cdata->lookup_opts & DEVICE_LOOKUP_USBMUX)) {
 				dev = &(dev_list[i]);
 				break;
-			} else if (dev_list[i].conn_type == CONNECTION_TYPE_NETWORK && (cdata->lookup_opts & DEVICE_LOOKUP_NETWORK)) {
+			}
+			if (dev_list[i].conn_type == CONNECTION_TYPE_NETWORK && (cdata->lookup_opts & DEVICE_LOOKUP_NETWORK)) {
 				dev = &(dev_list[i]);
 				break;
 			}
@@ -459,28 +460,28 @@ int main(int argc, char **argv)
 				if (c_sock < 0) {
 					fprintf(stderr, "accept: %s\n", strerror(errno));
 					break;
-				} else {
-					printf("New connection for %d->%d, fd = %d\n", listen_port[listen_sock[i].index], device_port[listen_sock[i].index], c_sock);
-					cdata = (struct client_data*)malloc(sizeof(struct client_data));
-					if (!cdata) {
-						socket_close(c_sock);
-						fprintf(stderr, "ERROR: Out of memory\n");
-						free(device_udid);
-						return -1;
-					}
-					cdata->fd = c_sock;
-					cdata->sfd = -1;
-					cdata->udid = (device_udid) ? strdup(device_udid) : NULL;
-					cdata->lookup_opts = lookup_opts;
-					cdata->device_port = device_port[listen_sock[i].index];
-#ifdef WIN32
-					acceptor = CreateThread(NULL, 0, (LPTHREAD_START_ROUTINE)acceptor_thread, cdata, 0, NULL);
-					CloseHandle(acceptor);
-#else
-					pthread_create(&acceptor, NULL, acceptor_thread, cdata);
-					pthread_detach(acceptor);
-#endif
 				}
+
+				printf("New connection for %d->%d, fd = %d\n", listen_port[listen_sock[i].index], device_port[listen_sock[i].index], c_sock);
+				cdata = (struct client_data*)malloc(sizeof(struct client_data));
+				if (!cdata) {
+					socket_close(c_sock);
+					fprintf(stderr, "ERROR: Out of memory\n");
+					free(device_udid);
+					return -1;
+				}
+				cdata->fd = c_sock;
+				cdata->sfd = -1;
+				cdata->udid = (device_udid) ? strdup(device_udid) : NULL;
+				cdata->lookup_opts = lookup_opts;
+				cdata->device_port = device_port[listen_sock[i].index];
+#ifdef WIN32
+				acceptor = CreateThread(NULL, 0, (LPTHREAD_START_ROUTINE)acceptor_thread, cdata, 0, NULL);
+				CloseHandle(acceptor);
+#else
+				pthread_create(&acceptor, NULL, acceptor_thread, cdata);
+				pthread_detach(acceptor);
+#endif
 			}
 		}
 	}


### PR DESCRIPTION
Found with readability-else-after-return

Signed-off-by: Rosen Penev <rosenp@gmail.com>