### PR TITLE
clang-tidy: add parentheses to macro arguments

### DIFF
--- a/common/collection.c
+++ b/common/collection.c
@@ -31,7 +31,7 @@
 #undef NDEBUG // we need to make sure we still get assertions because we can't handle memory allocation errors
 #include <assert.h>
 
-#define INIT_NULL(addr, count) { unsigned int i_ = 0; for (i_ = 0; i_ < count; i_++) ((void**)addr)[i_] = NULL; }
+#define INIT_NULL(addr, count) { unsigned int i_ = 0; for (i_ = 0; i_ < (count); i_++) ((void**)(addr))[i_] = NULL; }
 
 #define CAPACITY_STEP 8
 

--- a/tools/iproxy.c
+++ b/tools/iproxy.c
@@ -68,9 +68,9 @@ struct client_data {
 };
 
 #define CDATA_FREE(x) if (x) { \
-	if (x->fd > 0) socket_close(x->fd); \
-	if (x->sfd > 0) socket_close(x->sfd); \
-	free(x->udid); \
+	if ((x)->fd > 0) socket_close((x)->fd); \
+	if ((x)->sfd > 0) socket_close((x)->sfd); \
+	free((x)->udid); \
 	free(x); \
 }
 


### PR DESCRIPTION
Found with bugprone-macro-parentheses

Signed-off-by: Rosen Penev <rosenp@gmail.com>