### PR TITLE
clang-tidy: sort includes alphabetically

### DIFF
--- a/common/collection.c
+++ b/common/collection.c
@@ -23,10 +23,10 @@
 #include <config.h>
 #endif
 
+#include "collection.h"
+#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <stdio.h>
-#include "collection.h"
 
 #undef NDEBUG // we need to make sure we still get assertions because we can't handle memory allocation errors
 #include <assert.h>

--- a/common/socket.c
+++ b/common/socket.c
@@ -22,14 +22,14 @@
 #ifdef HAVE_CONFIG_H
 #include <config.h>
 #endif
-#include <stdio.h>
+#include <errno.h>
 #include <stddef.h>
+#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <unistd.h>
-#include <errno.h>
-#include <sys/time.h>
 #include <sys/stat.h>
+#include <sys/time.h>
+#include <unistd.h>
 #ifdef WIN32
 #include <winsock2.h>
 #include <ws2tcpip.h>
@@ -45,16 +45,16 @@ static int wsa_init = 0;
 #define AI_NUMERICSERV 0
 #endif
 #else
-#include <sys/socket.h>
-#include <sys/un.h>
-#include <netinet/in.h>
-#include <netinet/tcp.h>
-#include <netdb.h>
 #include <arpa/inet.h>
 #include <fcntl.h>
+#include <netdb.h>
+#include <netinet/in.h>
+#include <netinet/tcp.h>
+#include <sys/socket.h>
+#include <sys/un.h>
 #ifdef AF_INET6
-#include <net/if.h>
 #include <ifaddrs.h>
+#include <net/if.h>
 #endif
 #endif
 #include "socket.h"

--- a/src/libusbmuxd.c
+++ b/src/libusbmuxd.c
@@ -23,10 +23,10 @@
 #ifdef HAVE_CONFIG_H
 #include <config.h>
 #endif
-#include <stdint.h>
-#include <stdlib.h>
 #include <errno.h>
+#include <stdint.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 
 #ifdef WIN32
@@ -49,8 +49,8 @@
 #define ECONNREFUSED 107
 #endif
 
-#include <unistd.h>
 #include <signal.h>
+#include <unistd.h>
 
 #ifdef WIN32
 #include <winsock2.h>
@@ -59,9 +59,9 @@
 #define sleep(x) Sleep(x*1000)
 #endif
 #else
-#include <sys/socket.h>
 #include <arpa/inet.h>
 #include <pthread.h>
+#include <sys/socket.h>
 #if defined(HAVE_PROGRAM_INVOCATION_SHORT_NAME) && !defined(HAVE_PROGRAM_INVOCATION_SHORT_NAME_ERRNO_H)
 extern char *program_invocation_short_name;
 #endif

--- a/tools/inetcat.c
+++ b/tools/inetcat.c
@@ -27,24 +27,24 @@
 
 #define TOOL_NAME "inetcat"
 
+#include <errno.h>
+#include <fcntl.h>
+#include <getopt.h>
+#include <stddef.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <stdint.h>
 #include <string.h>
-#include <fcntl.h>
-#include <stddef.h>
 #include <unistd.h>
-#include <errno.h>
-#include <getopt.h>
 #ifdef WIN32
 #include <windows.h>
 #include <winsock2.h>
 #else
+#include <signal.h>
+#include <sys/ioctl.h>
 #include <sys/select.h>
 #include <sys/socket.h>
 #include <sys/un.h>
-#include <sys/ioctl.h>
-#include <signal.h>
 #endif
 
 #include "usbmuxd.h"

--- a/tools/iproxy.c
+++ b/tools/iproxy.c
@@ -29,26 +29,26 @@
 
 #define TOOL_NAME "iproxy"
 
+#include <errno.h>
+#include <fcntl.h>
+#include <getopt.h>
+#include <stddef.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <fcntl.h>
-#include <stddef.h>
 #include <unistd.h>
-#include <errno.h>
-#include <getopt.h>
 #ifdef WIN32
 #include <winsock2.h>
 #include <windows.h>
 typedef unsigned int socklen_t;
 #else
+#include <arpa/inet.h>
+#include <netinet/in.h>
+#include <pthread.h>
+#include <signal.h>
 #include <sys/select.h>
 #include <sys/socket.h>
 #include <sys/un.h>
-#include <arpa/inet.h>
-#include <pthread.h>
-#include <netinet/in.h>
-#include <signal.h>
 #endif
 #include "socket.h"
 #include "usbmuxd.h"


### PR DESCRIPTION
Found with llvm-include-order

Signed-off-by: Rosen Penev <rosenp@gmail.com>