### PR TITLE
docs: fix simple typo, occured -> occurred

### DIFF
--- a/src/libusbmuxd.c
+++ b/src/libusbmuxd.c
@@ -1368,7 +1368,7 @@ retry:
 			free(payload);
 		} else {
 			// we _should_ have all of them now.
-			// or perhaps an error occured.
+			// or perhaps an error occurred.
 			break;
 		}
 	}


### PR DESCRIPTION
There is a small typo in src/libusbmuxd.c.

Should read `occurred` rather than `occured`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md