### PR TITLE
fixed usbmuxd_send case dead-loop on windows

### DIFF
--- a/src/libusbmuxd.c
+++ b/src/libusbmuxd.c
@@ -55,6 +55,7 @@
 #ifdef WIN32
 #include <winsock2.h>
 #include <windows.h>
+#define errno WSAGetLastError()
 #ifndef HAVE_SLEEP
 #define sleep(x) Sleep(x*1000)
 #endif


### PR DESCRIPTION
On windows, errno will not be set when socket send failed, see
https://docs.microsoft.com/en-us/windows/win32/winsock/error-codes-errno-h-errno-and-wsagetlasterror-2