### PR TITLE
fixed usbmuxd_send case dead-loop on windows

### DIFF
--- a/src/libusbmuxd.c
+++ b/src/libusbmuxd.c
@@ -1592,7 +1592,11 @@ USBMUXD_API int usbmuxd_send(int sfd, const char *data, uint32_t len, uint32_t *
 	num_sent = socket_send(sfd, (void*)data, len);
 	if (num_sent < 0) {
 		*sent_bytes = 0;
+#ifdef WIN32
+		num_sent = WSAGetLastError();
+#else
 		num_sent = errno;
+#endif
 		LIBUSBMUXD_DEBUG(1, "%s: Error %d when sending: %s\n", __func__, num_sent, strerror(num_sent));
 		return -num_sent;
 	}


### PR DESCRIPTION
On windows, errno will not be set when socket send failed, see
https://docs.microsoft.com/en-us/windows/win32/winsock/error-codes-errno-h-errno-and-wsagetlasterror-2