### PR TITLE
inotify: Avoid leaking file descriptor to child processes

### DIFF
--- a/src/libusbmuxd.c
+++ b/src/libusbmuxd.c
@@ -914,7 +914,7 @@ static int usbmuxd_listen_inotify()
 		return sfd;
 
 	sfd = -1;
-	inot_fd = inotify_init ();
+	inot_fd = inotify_init1(IN_CLOEXEC);
 	if (inot_fd < 0) {
 		LIBUSBMUXD_DEBUG(1, "%s: Failed to setup inotify\n", __func__);
 		return -2;


### PR DESCRIPTION
inotify_init creates a file descriptor which by default is not makes with CLOEXEC. If the application using libusbmuxd spawns applications this then leaks through.

---
Downstream bug report: https://bugs.kde.org/show_bug.cgi?id=469889