### PR TITLE
Fix GLOBAL_CFLAGS syntax in configure.ac

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -119,7 +119,7 @@ AS_COMPILER_FLAGS(GLOBAL_CFLAGS, "-Wall -Wextra -Wmissing-declarations -Wredunda
 GLOBAL_LDFLAGS="$PTHREAD_LIBS"
 
 if test "x$enable_static" = "xyes" -a "x$enable_shared" = "xno"; then
-  GLOBAL_CFLAGS+=" -DLIBUSBMUXD_STATIC"
+  GLOBAL_CFLAGS="$GLOBAL_CFLAGS -DLIBUSBMUXD_STATIC"
 fi
 
 AC_SUBST(GLOBAL_CFLAGS)


### PR DESCRIPTION
It is not valid to use VAR+=value in configure.ac because this expression goes directly to configure which is a bash script.
This breaks static-only compilation. (In fact it is broken by 07cd6f7)
Same applies to libimobiledevice-glue, libimobiledevice and libplist; probably to other libs.